### PR TITLE
Fix unclosed value in network.cfg

### DIFF
--- a/cfg/arminc/network.cfg
+++ b/cfg/arminc/network.cfg
@@ -105,7 +105,7 @@ net_steamcnx_enabled "2"
 // <i> Value '>1' is splitting multiple packets per frame.
 // <i> A higher value reduces choke but is more CPU intensive.
 // <i> For bad CPUs that cannot handle the extra load is recommended to use the default value.
-net_splitrate "1
+net_splitrate "1"
 
 // Requested max packet size before packets are split. 
 // Default: 1200


### PR DESCRIPTION
I just noticed this while skimming over the entire script.
Not sure what happened with that last line, I edited it with GitHub's built-in editor.