### PR TITLE
Update audio.cfg

### DIFF
--- a/cfg/arminc/audio.cfg
+++ b/cfg/arminc/audio.cfg
@@ -163,9 +163,9 @@ cl_clutch_mode "0"
 // Default: 0
 //
 // <> Values:
-// 0: Pings will be silent.
-// 1: Player pinging will make a sound.
-cl_player_ping_mute "1"
+// 1: Pings will be silent.
+// 0: Player pinging will make a sound.
+cl_player_ping_mute "0"
 
 // Listen to the connected device through the microphone jack.
 // Default: 0


### PR DESCRIPTION
The **actual** values and behaviour of "1" and "0" are the opposite of what is described in your config. I also believe a sane value for this to be "0", as in NOT muted, but making noise. Please fix!