### PR TITLE
feat: bind [f3] -> autobuy

### DIFF
--- a/cfg/arminc/bind.cfg
+++ b/cfg/arminc/bind.cfg
@@ -127,7 +127,7 @@ bind "mouse5"         "+secondbinds"                            // Toggle the se
 // Function keys.
 bind "scancode58"     ""                                        // [f1] -
 bind "scancode59"     ""                                        // [f2] -
-bind "scancode60"     ""                                        // [f3] -
+bind "scancode60"     "autobuy"                                 // [f3] Enable/Disable Auto-buy at deathmatch gamemode.
 bind "scancode61"     "afk-move"                                // [f4] Toggle the AFK auto walk in a counter-clockwise circle movement {script}.
 bind "scancode62"     "clutch_mode_toggle; select"              // [f5] Toggle the clutch mode (silence the teammates until next round or death) {uses audio effect}.
 bind "scancode63"     "mute-enemy-team"                         // [f6] Toggle enemy team communication (disables the enemy chat too) {script}.


### PR DESCRIPTION
# New bind for [f3] key -> autobuy

## Description
Currently the [f3] key has no function, and the binds do not have the 'autobuy' function, which is necessary to Enable/Disable automatic weapon buying during deathmatch game mode. Since the default key for this function is [f3], I understand that it is necessary to assign its default function.

## Related issues
Start a deathmatch game, and see the hint as below:
![image](https://github.com/user-attachments/assets/c9d3bd7f-cb1b-48f8-8cb0-a2dbcfd570b7)

## Types of changes
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/ArmynC/ArminC-AutoExec/blob/master/.github/CONTRIBUTING.md) document.